### PR TITLE
Feat: Add toggle-able dark mode

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,6 +3,7 @@ import { SmoothScrollLink } from '@/components/ui/smooth-scroll-link';
 import { Button } from '@/components/ui/button';
 import { DownloadCloud, BrainCircuit, Linkedin, Github, Menu } from 'lucide-react';
 import { userData } from '@/data/user-data';
+import { ThemeToggleButton } from '@/components/ui/theme-toggle-button';
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from '@/components/ui/sheet';
 
 const Header = () => {
@@ -43,6 +44,7 @@ const Header = () => {
               Resume
             </Link>
           </Button>
+          <ThemeToggleButton />
           <Link href={userData.linkedinUrl} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors">
             <Linkedin className="h-6 w-6" />
           </Link>
@@ -87,6 +89,7 @@ const Header = () => {
                   </Link>
                 </Button>
                 <div className="flex justify-center space-x-4 pt-4 border-t border-border/40">
+                  <ThemeToggleButton />
                   <SheetClose asChild>
                     <Link href={userData.linkedinUrl} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-primary transition-colors">
                       <Linkedin className="h-7 w-7" />

--- a/src/components/ui/theme-toggle-button.tsx
+++ b/src/components/ui/theme-toggle-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggleButton() {
+  const [isDarkMode, setIsDarkMode] = React.useState(false);
+
+  React.useEffect(() => {
+    const currentTheme = localStorage.getItem("theme");
+    if (currentTheme === "dark") {
+      setIsDarkMode(true);
+      document.documentElement.classList.add("dark");
+    } else if (currentTheme === "light") {
+      setIsDarkMode(false);
+      document.documentElement.classList.remove("dark");
+    } else {
+      // Default to light theme or system preference if you want to implement that later
+      // For now, defaulting to light if no preference is stored
+      setIsDarkMode(false);
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    if (isDarkMode) {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+      setIsDarkMode(false);
+    } else {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+      setIsDarkMode(true);
+    }
+  };
+
+  return (
+    <Button variant="outline" size="icon" onClick={toggleTheme}>
+      {isDarkMode ? (
+        <Moon className="h-[1.2rem] w-[1.2rem]" />
+      ) : (
+        <Sun className="h-[1.2rem] w-[1.2rem]" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
- Implemented a theme toggle button that allows you to switch between light and dark themes.
- Your theme preference is persisted in localStorage.
- Leveraged existing CSS variables and Tailwind CSS dark mode configuration.
- Added the toggle button to both desktop and mobile navigation in the header.